### PR TITLE
listen zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ fastcgi_param  DIET_ENV development;
 ### Run with PHP built-in server
 
 ```
-DIET_ENV=development php -d variables_order=EGPCS -S localhost:8080 -t webroot/
+DIET_ENV=development php -d variables_order=EGPCS -S 0:8080 -t webroot/
 ```


### PR DESCRIPTION
I saw the installer script shows message to use address 0.
Address 0  seems to be more useful than `localhost`, especially when we run server on VMs.

